### PR TITLE
Adicionada opção para preservar últimas linhas em branco ao salvar o arquivo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ O repositório começou com o código fonte original, que inevitavelmente ficará de
 * Removida mensagem de configuração "aguarde, configurando" - @thgcode
 * Adicionada opção de configuração para especificar se a tecla tab insere "\t" ou espaços - @thgcode
 * Adicionada opção de configuração para determinar codificação ao salvar arquivo - @thgcode
+* Adicionada opção de configuração para preservar últimas linhas em branco ao salvar o arquivo - @JosielSantos
 
 [sist_dosvox]: http://intervox.nce.ufrj.br/dosvox/

--- a/src/EDCONFIG.PAS
+++ b/src/EDCONFIG.PAS
@@ -33,7 +33,7 @@ implementation
 procedure formConfig;
 var velGeral: integer;
     confInsLinha, confQuebra, confPontuacao, confSoletrando, confFalandoPalavra, confAutomatica,
-    confDicio, confCorrige, confSapi, confFormat, confUsaTab, confCodif: shortString;
+    confDicio, confCorrige, confSapi, confFormat, confUsaTab, confCodif, confPreservaUltimasLinhasEmBranco: shortString;
     confTipoSapi, confNum, confVeloc, confTonal, confTamanhoTab, erro: integer;
     i: integer;
     s: string;
@@ -52,7 +52,7 @@ begin
     confDicio      := (sintAmbiente('EDIVOX', 'DICIONARIOATIVADO'));
     confCorrige    := (sintAmbiente('EDIVOX', 'CORRIGIRTODOTEXTO'));
     confFormat := (sintAmbiente('EDIVOX', 'MODOFALAFORMATACAO'));
-
+    confPreservaUltimasLinhasEmBranco := (sintAmbiente('EDIVOX', 'PRESERVAULTIMASLINHASEMBRANCO'));
     confSapi       := (sintAmbiente('EDIVOX', 'SAPIATIVADO'));
 
     val (sintAmbiente('EDIVOX', 'TIPOSAPI'), confTipoSapi, erro);
@@ -112,6 +112,7 @@ begin
     formCampoInt ('EDTATAB',   txtmsg('EDTATAB')   {'tab: '}, confTamanhoTab); {''}
     formCampo ('EDUSATAB',   txtmsg('EDUSATAB')   {'tab: '}, confUsaTab, 4); {''}
     formCampo ('EDCODIF',   txtmsg('EDCODIF')   {'Salva em qual codificação'}, confCodif, 10); {''}
+    formCampo    ('EDPRESERVULTLB', txtmsg('EDPRESERVULTLB') {'Preserva últimas linhas em branco'},           confPreservaUltimasLinhasEmBranco, 4); {''}
     formEdita (true);
 
     //Efetuando modificações
@@ -173,10 +174,9 @@ begin
     sintGravaAmbiente ('EDIVOX', 'TAMANHOTAB', intToStr(tamanhoTab));
     sintGravaAmbiente ('EDIVOX', 'CARACTERESTAB', confUsaTab);
     sintGravaAmbiente ('EDIVOX', 'CODIFICACAO', confCodif);
+    sintGravaAmbiente ('EDIVOX', 'PRESERVAULTIMASLINHASEMBRANCO', confPreservaUltimasLinhasEmBranco);
     colocaCodificacaoPadrao;
-
     comTabs := primeiraLetra (sintAmbiente ('EDIVOX', 'CARACTERESTAB')) = 'S';
-
     sintPara;
 
     s := sintAmbiente ('EDIVOX', 'VELOCIDADE');

--- a/src/EDMENSAG.PAS
+++ b/src/EDMENSAG.PAS
@@ -864,6 +864,8 @@ begin
     else if f = 'EDTATAB' then txtmsg := 'Número de espaços ao apertar tab'
     else if f = 'EDUSATAB' then txtmsg := 'Usa o caractere tab'
     else if f = 'EDCODIF' then txtmsg := 'Salva em qual codificação'
+    else if f = 'EDPRESERVULTLB' then txtmsg := 'Preserva últimas linhas em branco?'
+
     else
         txtmsg := '----- erro de mensagem ???? ----';
 end;

--- a/src/edArq.pas
+++ b/src/edArq.pas
@@ -493,6 +493,7 @@ procedure salvaArquivo (linha1, linha2: integer);
 var
     i, j: integer;
     s: string;
+    preservaUltimasLinhasEmbranco: boolean;
 label inicio, fechaArq;
 begin
 
@@ -518,8 +519,12 @@ inicio:
     {$I+}
     ioresult;   // ignora erros
 
-    while (linha2 >= linha1) and (texto[linha2] = '') do
+    preservaUltimasLinhasEmBranco := primeiraLetra (sintAmbiente ('EDIVOX', 'PRESERVAULTIMASLINHASEMBRANCO')) = 'S';
+    if not preservaUltimasLinhasEmBranco then
+    begin
+        while (linha2 >= linha1) and (texto[linha2] = '') do
             linha2 := linha2 - 1;
+    end;
 
     For i := linha1 to linha2 Do
         begin


### PR DESCRIPTION
Atualmente o edivox não preserva as últimas linhas em branco de um arquivo.
Esse PR adiciona uma opção de configuração para preservar, ou não, essas linhas.