### PR TITLE
Remodelação da interface da troca de textos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ O repositório começou com o código fonte original, que inevitavelmente ficará de
 * Adicionada opção de configuração para especificar se a tecla tab insere "\t" ou espaços - @thgcode
 * Adicionada opção de configuração para determinar codificação ao salvar arquivo - @thgcode
 * Adicionada opção de configuração para preservar últimas linhas em branco ao salvar o arquivo - @JosielSantos
-* Adicionada opção de configuração para usar fim de linha Unix ou Windows
+* Adicionada opção de configuração para usar fim de linha Unix ou Windows - @JosielSantos
+* Remodelado o sistema de troca de textos para ser um formulário, para poder adicionar mais opções facilmente - @thgcode
 
 [sist_dosvox]: http://intervox.nce.ufrj.br/dosvox/

--- a/src/EDBUSCA.PAS
+++ b/src/EDBUSCA.PAS
@@ -144,8 +144,7 @@ end;
 
 procedure trocaPalavra;
 var
-    c: char;
-    buscado, aTrocar: string;
+    op, buscado, aTrocar: shortString;
     nl: integer;
     achou: boolean;
     totalPalavras: int64;
@@ -182,32 +181,49 @@ var
         texto[nl] := saida;
     end;
 
-begin
-    fala ('EDTXTPRC');
+const
+    nOpcoesForm = 3; { qual o texto, qual substituir e se é para trocar no texto inteiro ou no bloco }
 
-    sintReadln (buscado);
+begin
+    buscado := '';
+    aTrocar := '';
+    op := '';
+    garanteEspacoTela (nOpcoesForm + 1); { mais uma linha para dizer se o texto foi trocado ou não}
+
+    formCria;
+    formCampo ('EDTXTPRC', txtmsg('EDTXTPRC') {'Qual o texto?'}, buscado, 250);
+    formCampo ('EDINFTXT', txtmsg('EDINFTXT') {'Informe o novo texto:'}, aTrocar, 250);
+    formCampoLista ('EDTODBLK', txtmsg('EDTODBLK') {'T para todo texto ou b para bloco?'}, op, 1, 'T|B');
+    formEdita (true);
+
     if buscado = '' then
         begin
             fala ('EDDESIST');
             exit;
         end;
 
-    fala ('EDINFTXT');
-    sintReadln (aTrocar);
+    op := maiuscAnsi (op);
 
-    repeat
+    if op = '' then
+        begin
+            fala ('EDDESIST');
+            exit;
+        end;
+
+    while not (op[1] in ['T', 'B']) do
+        begin
         fala ('EDTODBLK');
-        c := popupMenuPorLetra ('TB');
-        if c = #$1b then
+        op := maiuscAnsi(popupMenuPorLetra('TB'));
+        if op = '' + ESC then
             begin
-                fala ('EDDESIST');
-                exit;
-            end;
-    until c in ['T', 'B'];
+            fala ('EDDESIST');
+            exit;
+        end;
+    end;
 
     totalPalavras := 0;
     achou := false;
-    if c = 'T' then
+    if op = 'T' then
         begin
             for nl := 1 to maxLinhas do
                 if trocaTexto (nl) then achou := true;


### PR DESCRIPTION
Essa reforma é pra facilitar depois na hora de inserir novos campos como a regex na interface de troca de textos.