### PR TITLE
Adicionar função para buscar por expressões regulares.

### DIFF
--- a/src/EDBUSCA.PAS
+++ b/src/EDBUSCA.PAS
@@ -22,21 +22,45 @@ uses
     edBloco, edvars, edmensag, edAcento, edTela, edLinha, edCursor;
 
 procedure cmdBusca;
-procedure buscaDeNovo (paraTraz: boolean);
+procedure buscaDeNovo (paraTraz, regExp: boolean);
 procedure formatarBuscado;
-procedure buscaPalavra (paraTraz: boolean);
+procedure buscaPalavra (paraTraz, regExp: boolean);
 procedure trocaPalavra;
 procedure limpaTexto (limparTexto: boolean);
 
 implementation
-
-{--------------------------------------------------------}
+uses regExpr;
 
 var buscarIdentica: boolean;
 
 {--------------------------------------------------------}
+{ Verifica se a linha passada contém a cadeia buscada, retorna maior do que 0 se encontrou
+{--------------------------------------------------------}
 
-procedure buscaParaFrente;
+function tentaMatch(linha: string; regExp: boolean): integer; inline;
+    begin
+    if regexp then
+        begin
+        with tRegExpr.Create do
+            begin
+            try
+                expression := buscado;
+                if exec(linha) then
+                    result := 1 // TODO posicionar na posição exata
+                else
+                result := 0;
+            finally
+                free;
+            end;
+        end;
+    end
+    else
+        result := pos(buscado, linha);
+end;
+
+{--------------------------------------------------------}
+
+procedure buscaParaFrente(regExp: boolean);
 var i, x: integer;
     linha: string;
 begin
@@ -50,7 +74,7 @@ begin
                 for x := 1 to posx do
                     linha[x] := ^a;
 
-            x := pos (buscado, linha);
+            x := tentaMatch(linha, regExp);
             if x > 0 then
                 begin
                     fala ('EDTXTENC');
@@ -65,7 +89,7 @@ end;
 
 {--------------------------------------------------------}
 
-procedure buscaParaTraz;
+procedure buscaParaTraz(regExp: boolean);
 var i, x: integer;
     linha: string;
 begin
@@ -79,7 +103,7 @@ begin
                 for x :=  posx to length(linha) do
                     linha[x] := ^a;
 
-            x := pos (buscado, linha);
+            x := tentaMatch(linha, regExp);
             if x > 0 then
                 begin
                     fala ('EDTXTENC');
@@ -94,15 +118,15 @@ end;
 
 {--------------------------------------------------------}
 
-Procedure buscaDeNovo (paraTraz: boolean);
+Procedure buscaDeNovo (paraTraz, regExp: boolean);
 begin
     if buscado = '' then
-        buscaPalavra (paraTraz)
+        buscaPalavra (paraTraz, regExp)
     else
     if paraTraz then
-        buscaParaTraz
+        buscaParaTraz(regExp)
     else
-        buscaParaFrente;
+        buscaParaFrente(regExp);
 end;
 
 {--------------------------------------------------------}
@@ -122,11 +146,16 @@ end;
 
 {--------------------------------------------------------}
 
-Procedure buscaPalavra (paraTraz: boolean);
+Procedure buscaPalavra (paraTraz, regExp: boolean);
 var c: char;
 begin
     buscado := sintAmbiente ('EDIVOX', 'BUSCADO');
-    fala ('EDTXTPRC');
+
+    if regExp then
+        fala ('EDRGXPRC') { Qual expressão regular? }
+    else
+        fala ('EDTXTPRC'); { Qual o texto? }
+
     c := sintEditaCampo (buscado, 1, wherey, 255, 80, true);
     sintGravaAmbiente('EDIVOX', 'BUSCADO', buscado);
     formatarBuscado;
@@ -137,7 +166,7 @@ begin
             exit;
         end;
 
-    buscaDeNovo (paraTraz);
+    buscaDeNovo (paraTraz, regExp);
 end;
 
 {--------------------------------------------------------}
@@ -262,9 +291,9 @@ deNovo:
 
     case tecla of
 
-       'P': buscaPalavra (false);
-       'A': buscaPalavra (true);
-       'N': buscaDeNovo (false);
+       'P': buscaPalavra (false, false);
+       'A': buscaPalavra (true, false);
+       'N': buscaDeNovo (false, false);
        'T': trocaPalavra;
 
        #$0: begin

--- a/src/EDMENSAG.PAS
+++ b/src/EDMENSAG.PAS
@@ -574,6 +574,8 @@ begin
     else
     if f = 'EDTXTPRC' then txtmsg := 'Qual o texto ? '
     else
+    if f = 'EDRGXPRC' then txtmsg := 'Qual expressão regular ? '
+    else
     if f = 'EDTXTENC' then txtmsg := 'Texto encontrado'
     else
     if f = 'EDTXNENC' then txtmsg := 'Texto não encontrado'

--- a/src/edivox.dpr
+++ b/src/edivox.dpr
@@ -336,7 +336,7 @@ procedure trataPFeALT (tecla: char);
 var
     salva: integer;
     aux: boolean;
-    mantemMarca, saiuDaLinha, apertouShift: boolean;
+    mantemMarca, saiuDaLinha, apertouShift, apertouAlt: boolean;
     sf: string;
     n: integer;
 label reprocTecla;
@@ -344,6 +344,7 @@ begin
 reprocTecla:
 
     apertouShift := GetKeyState(VK_SHIFT) < 0;
+    apertouAlt := GetKeyState(VK_MENU) < 0;
     mantemMarca := apertouShift or
            (tecla = DEL) or (tecla = SHIFTINS) or (tecla = CTLINS);
     saiuDaLinha := (tecla in [ALTF1, F3, F5, CTLF5, F6, CTLF6,
@@ -421,13 +422,13 @@ reprocTecla:
                     formConfig;
 
         F5 : if apertouShift then
-                    buscaPalavra (true)
+                    buscaPalavra (true, apertouAlt)
                 else
-                    buscaPalavra (false);
+                    buscaPalavra (false, apertouAlt);
         CTLF5 : if apertouShift then
-                    buscaDeNovo (true)
+                    buscaDeNovo (true, apertouAlt)
                 else
-                    buscaDeNovo (false);
+                    buscaDeNovo (false, apertouAlt);
         F6:      trocaPalavra;
         CTLF6:   begin
                      if (pos ('=', texto[posy]) <> 0) and


### PR DESCRIPTION
Apertar alt f5 busca por expressões regulares.
Control Alt f5 busca de novo.

Por enquanto está com um pequeno bug que não foca no conteúdo que deu match na expressão regular.